### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,8 @@ before_install:
   - chmod +x gradlew
 
 # Extend compile timeout to 30 minutes; gwt easily takes 10+.
-script: travis_wait 30 ./gradlew clean build -x android:validateSigningDebug -x android:packageDebug -x matrix:generateMatrix
+script: ./gradlew clean build -x android:validateSigningDebug -x android:packageDebug -x matrix:generateMatrix
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
